### PR TITLE
bump(mdns): 1.0.9 -> 1.1.0

### DIFF
--- a/.github/workflows/publish-docs-component.yml
+++ b/.github/workflows/publish-docs-component.yml
@@ -16,8 +16,6 @@ jobs:
   publish:
     name: Publish Tag, Release, Docs, Component
     runs-on: ubuntu-latest
-    # Skip running on forks since it won't have access to secrets
-    if: github.repository == 'espressif/esp-protocols'
     steps:
       - name: Checkout esp-protocols
         uses: actions/checkout@v3

--- a/components/mdns/.cz.yaml
+++ b/components/mdns/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(mdns): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py mdns
   tag_format: mdns-v$version
-  version: 1.0.9
+  version: 1.1.0
   version_files:
   - idf_component.yml

--- a/components/mdns/CHANGELOG.md
+++ b/components/mdns/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [1.1.0](https://github.com/espressif/esp-protocols/commits/mdns-v1.1.0)
+
+### Features
+
+- Decouple main module from mdns-networking ([d238e93](https://github.com/espressif/esp-protocols/commit/d238e93))
+
+### Bug Fixes
+
+- Use idf-build-apps package for building mdns ([1a0a41f](https://github.com/espressif/esp-protocols/commit/1a0a41f))
+- socket networking to init interfaces properly ([ee9b04f](https://github.com/espressif/esp-protocols/commit/ee9b04f))
+- Removed unused internal lock from mdns_server struct ([a06fb77](https://github.com/espressif/esp-protocols/commit/a06fb77))
+- Resolve conflicts only on self hosted items ([e69a9eb](https://github.com/espressif/esp-protocols/commit/e69a9eb), [#185](https://github.com/espressif/esp-protocols/issues/185))
+- Fix memory issues reported by valgrind ([0a682e7](https://github.com/espressif/esp-protocols/commit/0a682e7))
+
+### Updated
+
+- docs(common): updated component and example links ([f48d9b2](https://github.com/espressif/esp-protocols/commit/f48d9b2))
+- Add APIs to look up delegated services ([87dcd7d](https://github.com/espressif/esp-protocols/commit/87dcd7d))
+- Fix deadly mdns crash ([4fa3023](https://github.com/espressif/esp-protocols/commit/4fa3023))
+- docs(common): improving documentation ([ca3fce0](https://github.com/espressif/esp-protocols/commit/ca3fce0))
+- append all ipv6 address in mdns answer ([5ed3e9a](https://github.com/espressif/esp-protocols/commit/5ed3e9a))
+- test(mdns): Host tests to use IDF's esp_event_stub ([537d170](https://github.com/espressif/esp-protocols/commit/537d170))
+
 ## [1.0.9](https://github.com/espressif/esp-protocols/commits/mdns-v1.0.9)
 
 ### Features

--- a/components/mdns/idf_component.yml
+++ b/components/mdns/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.9"
+version: "1.1.0"
 description: mDNS
 url: https://github.com/espressif/esp-protocols/tree/master/components/mdns
 dependencies:


### PR DESCRIPTION
1.1.0
Features
- Decouple main module from mdns-networking (d238e93) Bug Fixes
- Use idf-build-apps package for building mdns (1a0a41f)
- socket networking to init interfaces properly (ee9b04f)
- Removed unused internal lock from mdns_server struct (a06fb77)
- Resolve conflicts only on self hosted items (e69a9eb, #185)
- Fix memory issues reported by valgrind (0a682e7) Updated
- docs(common): updated component and example links (f48d9b2)
- Add APIs to look up delegated services (87dcd7d)
- Fix deadly mdns crash (4fa3023)
- docs(common): improving documentation (ca3fce0)
- append all ipv6 address in mdns answer (5ed3e9a)
- test(mdns): Host tests to use IDF's esp_event_stub (537d170)